### PR TITLE
Places LSP functionality into new subcommand and adds init subcommand to initialize the project's root in a directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +63,36 @@ dependencies = [
  "num-traits",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b9752c030a14235a0bd5ef3ad60a1dcac8468c30921327fc8af36b20c790b9"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -106,6 +147,7 @@ name = "grimoire-lsp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "log",
  "log4rs",
  "lsp-server",
@@ -119,6 +161,24 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "humantime"
@@ -298,6 +358,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +396,30 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -461,6 +554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +569,21 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -559,6 +673,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +707,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +733,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.52"
+clap = { version = "3.0.0", features = ["derive"] }
 log = "0.4.14"
 log4rs = "1.0.0"
 lsp-server = "0.5.2"

--- a/src/bin/grimoire-lsp.rs
+++ b/src/bin/grimoire-lsp.rs
@@ -1,3 +1,0 @@
-fn main() -> grimoire_lsp::Result<()> {
-    grimoire_lsp::lsp::run()
-}

--- a/src/bin/grimoire.rs
+++ b/src/bin/grimoire.rs
@@ -1,0 +1,18 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[clap(name = "grimoire")]
+#[clap(bin_name = "grimoire")]
+enum Grimoire {
+    /// Initializes a Grimoire project
+    Init(grimoire_lsp::init::Init),
+    /// Runs the LSP server for a Grimoire project
+    Lsp(grimoire_lsp::lsp::Lsp),
+}
+
+fn main() -> grimoire_lsp::Result<()> {
+    match Grimoire::parse() {
+        Grimoire::Init(args) => grimoire_lsp::init::call(args),
+        Grimoire::Lsp(args) => grimoire_lsp::lsp::run(args),
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,41 @@
+use anyhow::anyhow;
+
+pub type Error = anyhow::Error;
+
+pub fn project_uninitialized() -> Error {
+    anyhow!("A Grimoire project hasn't been initialized yet.")
+}
+
+pub fn project_already_initialized() -> Error {
+    anyhow!("A Grimoire project has already been initialized.")
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
+    pub fn error() -> Error {
+        anyhow!("A test error")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_project_uninitialized() {
+        assert_eq!(
+            project_uninitialized().to_string(),
+            "A Grimoire project hasn't been initialized yet."
+        );
+    }
+
+    #[test]
+    fn test_project_already_initialized() {
+        assert_eq!(
+            project_already_initialized().to_string(),
+            "A Grimoire project has already been initialized."
+        );
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,18 @@
+#[derive(clap::Args, Debug)]
+#[clap(about, author, version)]
+pub struct Init {}
+
+pub fn call(_args: Init) -> crate::Result<()> {
+    if crate::project_root::ProjectRoot::current(()).is_some() {
+        return Err(crate::errors::project_already_initialized());
+    }
+
+    let project_root = crate::project_root::ProjectRoot::new(())?;
+
+    std::fs::create_dir_all(project_root.log_file_directory())?;
+    std::fs::File::create(project_root.log_file_path())?;
+
+    std::fs::File::create(project_root.config_file_path())?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 pub type Result<T> = anyhow::Result<T>;
 
+pub mod errors;
+pub mod init;
 pub mod logger;
 pub mod lsp;
 pub mod project_root;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -9,23 +9,28 @@ use std::env;
 
 const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Warn;
 
-pub fn initialize_logger() -> anyhow::Result<Handle> {
-    let project_root = crate::project_root::ProjectRoot::current()?;
+pub fn initialize_logger() -> crate::Result<Handle> {
+    let project_root = crate::project_root::ProjectRoot::current(())
+        .ok_or_else(crate::errors::project_uninitialized)?;
 
     let log = FileAppender::builder()
         .encoder(Box::new(PatternEncoder::new("{d} - {m}{n}")))
-        .build(project_root.log_file_path()?)?;
+        .build(project_root.log_file_path())?;
 
     let log_config = Config::builder()
         .appender(Appender::builder().build("log", Box::new(log)))
-        .build(Root::builder().appender("log").build(log_level()))?;
+        .build(
+            Root::builder()
+                .appender("log")
+                .build(log_level(env_var_log_level())),
+        )?;
 
     let handle = log4rs::init_config(log_config).unwrap();
     Ok(handle)
 }
 
-fn log_level() -> LevelFilter {
-    match env::var("GRIMOIRE_LOG_LEVEL") {
+fn log_level(env_var_log_level: crate::Result<String>) -> LevelFilter {
+    match env_var_log_level {
         Ok(lvl) => match &*lvl {
             "off" => LevelFilter::Off,
             "error" => LevelFilter::Error,
@@ -39,12 +44,54 @@ fn log_level() -> LevelFilter {
     }
 }
 
+fn env_var_log_level() -> crate::Result<String> {
+    env::var("GRIMOIRE_LOG_LEVEL").map_err(|e| e.into())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn log_level_default() {
-        assert_eq!(LevelFilter::Warn, log_level());
+    fn test_log_level_default() {
+        assert_eq!(
+            LevelFilter::Warn,
+            log_level(Err(crate::errors::test::error()))
+        );
+    }
+
+    #[test]
+    fn test_log_level_unrecognized() {
+        assert_eq!(LevelFilter::Warn, log_level(Ok("foo".into())));
+    }
+
+    #[test]
+    fn test_log_level_off() {
+        assert_eq!(LevelFilter::Off, log_level(Ok("off".into())));
+    }
+
+    #[test]
+    fn test_log_level_error() {
+        assert_eq!(LevelFilter::Error, log_level(Ok("error".into())));
+    }
+
+    #[test]
+    fn test_log_level_warn() {
+        assert_eq!(LevelFilter::Warn, log_level(Ok("warn".into())));
+    }
+
+    #[test]
+    fn test_log_level_info() {
+        assert_eq!(LevelFilter::Info, log_level(Ok("info".into())));
+    }
+
+    #[test]
+    fn test_log_level_debug() {
+        assert_eq!(LevelFilter::Debug, log_level(Ok("debug".into())));
+    }
+
+    #[test]
+    fn test_log_level_trace() {
+        assert_eq!(LevelFilter::Trace, log_level(Ok("trace".into())));
     }
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -3,7 +3,11 @@ use lsp_types::{request::GotoDefinition, GotoDefinitionResponse, Location, Range
 
 use log::info;
 
-pub fn run() -> anyhow::Result<()> {
+#[derive(clap::Args, Debug)]
+#[clap(about, author, version)]
+pub struct Lsp {}
+
+pub fn run(_args: Lsp) -> crate::Result<()> {
     crate::logger::initialize_logger()?;
 
     info!("starting up lsp server");
@@ -20,7 +24,7 @@ pub fn run() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn main_loop(connection: Connection) -> anyhow::Result<()> {
+pub fn main_loop(connection: Connection) -> crate::Result<()> {
     info!("starting main loop");
 
     for msg in &connection.receiver {

--- a/src/project_root.rs
+++ b/src/project_root.rs
@@ -1,8 +1,7 @@
-use anyhow::anyhow;
-
 use std::path::PathBuf;
 
 const CONFIG_DIRECTORY_NAME: &str = ".grimoire";
+const CONFIG_FILE_NAME: &str = "config.toml";
 const LOG_DIRECTORY_NAME: &str = "logs";
 const LOG_FILE_NAME: &str = "log.txt";
 
@@ -12,32 +11,133 @@ pub struct ProjectRoot {
 }
 
 impl ProjectRoot {
-    pub fn current() -> anyhow::Result<Self> {
-        // It seems as though the LSP client sets the current working directory
-        // to be the root directory that it's been configured with?
-        // I'm not sure if all clients would do this or only Neovim's LSP client.
-        // In any case, I'm raising an error here if there's an exception to this rule.
-        let dir = std::env::current_dir()?.join(CONFIG_DIRECTORY_NAME);
-        if !dir.exists() {
-            return Err(anyhow!(
-                "This directory isn't a part of a Grimoire project."
-            ));
+    pub fn current<T>(args: T) -> Option<Self>
+    where
+        T: Into<CurrentDirectoryArgs>,
+    {
+        let mut dir = args.into().current_dir.ok()?;
+        loop {
+            let config_dir = dir.join(CONFIG_DIRECTORY_NAME);
+            match config_dir.exists() {
+                true => {
+                    break Some(Self {
+                        filepath: config_dir,
+                    })
+                }
+                false => match dir.parent() {
+                    Some(dir_parent) => dir = dir_parent.to_path_buf(),
+                    None => break None,
+                },
+            }
         }
-
-        Ok(Self { filepath: dir })
     }
 
-    pub fn log_file_path(&self) -> anyhow::Result<PathBuf> {
-        let log_directory = self.filepath.join(LOG_DIRECTORY_NAME);
-        if !log_directory.exists() {
-            std::fs::create_dir_all(&log_directory)?;
-        }
+    pub fn new<T>(args: T) -> crate::Result<Self>
+    where
+        T: Into<CurrentDirectoryArgs>,
+    {
+        let dir = args.into().current_dir?;
+        Ok(Self {
+            filepath: dir.join(CONFIG_DIRECTORY_NAME),
+        })
+    }
 
-        let log_file = log_directory.join(LOG_FILE_NAME);
-        if !log_file.exists() {
-            std::fs::File::create(&log_file)?;
-        }
+    pub fn config_file_path(&self) -> PathBuf {
+        self.filepath.join(CONFIG_FILE_NAME)
+    }
+    pub fn log_file_path(&self) -> PathBuf {
+        self.log_file_directory().join(LOG_FILE_NAME)
+    }
 
-        Ok(log_file.canonicalize()?)
+    pub fn log_file_directory(&self) -> PathBuf {
+        self.filepath.join(LOG_DIRECTORY_NAME)
+    }
+}
+
+#[derive(Debug)]
+pub struct CurrentDirectoryArgs {
+    current_dir: crate::Result<PathBuf>,
+}
+impl Default for CurrentDirectoryArgs {
+    fn default() -> Self {
+        Self {
+            current_dir: std::env::current_dir().map_err(|e| e.into()),
+        }
+    }
+}
+impl From<()> for CurrentDirectoryArgs {
+    fn from(_: ()) -> Self {
+        Self::default()
+    }
+}
+
+impl From<PathBuf> for CurrentDirectoryArgs {
+    fn from(current_dir: PathBuf) -> Self {
+        Self {
+            current_dir: Ok(current_dir),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_current_directory_args_default() {
+        assert!(CurrentDirectoryArgs::default().current_dir.is_ok());
+    }
+
+    #[test]
+    fn test_current_directory_args_from_unit() {
+        let current_directory_args: CurrentDirectoryArgs = ().into();
+        assert!(current_directory_args.current_dir.is_ok());
+    }
+
+    #[test]
+    fn test_current_directory_args_from_path_buf() {
+        let path_buf = PathBuf::from("~");
+        let current_directory_args: CurrentDirectoryArgs = path_buf.clone().into();
+        assert_eq!(current_directory_args.current_dir.unwrap(), path_buf);
+    }
+
+    #[test]
+    fn test_project_root_new_unit() {
+        assert!(ProjectRoot::new(()).is_ok());
+    }
+
+    #[test]
+    fn test_project_root_new_path_buf() {
+        assert!(ProjectRoot::new(PathBuf::from("~")).is_ok());
+    }
+
+    #[test]
+    fn test_project_root_config_file_path() {
+        let path_buf = PathBuf::from("~");
+        let project_root = ProjectRoot::new(path_buf).unwrap();
+        assert_eq!(
+            project_root.config_file_path(),
+            PathBuf::from("~/.grimoire/config.toml")
+        );
+    }
+
+    #[test]
+    fn test_project_root_log_file_directory() {
+        let path_buf = PathBuf::from("~");
+        let project_root = ProjectRoot::new(path_buf).unwrap();
+        assert_eq!(
+            project_root.log_file_directory(),
+            PathBuf::from("~/.grimoire/logs")
+        );
+    }
+
+    #[test]
+    fn test_project_root_log_file_path() {
+        let path_buf = PathBuf::from("~");
+        let project_root = ProjectRoot::new(path_buf).unwrap();
+        assert_eq!(
+            project_root.log_file_path(),
+            PathBuf::from("~/.grimoire/logs/log.txt")
+        );
     }
 }


### PR DESCRIPTION
This PR adds the `clap` dependency for parsing CLI arguments and showing help messages. It also splits the existing functionality into two subcommands exposed from the CLI:
- `init` initializes the project's root in a new directory, which creates a `.grimoire` hidden directory with configuration and logs
- `lsp` starts the LSP server for use with the editor's LSP client

In addition, error messages were consolidated into the `errors` module, and lots of functionality was refactored to make it more testable. 