### PR TITLE
Uses the built files index in LSP mode to resolve a Goto request from a source file reference to the destination file header

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,18 @@ pub fn project_already_initialized() -> Error {
     anyhow!(msg)
 }
 
+pub fn invalid_path_from_url(url: lsp_types::Url) -> Error {
+    let msg = format!("Invalid path extracted from url {url:?}");
+    log::error!("{}", msg);
+    anyhow!(msg)
+}
+
+pub fn invalid_overlapping_references_in_file(file: &File) -> Error {
+    let msg = format!("Invalid overlapping references in file: {file:?}");
+    log::error!("{}", msg);
+    anyhow!(msg)
+}
+
 pub fn markdown_header_not_found_during_parsing(path: &Path) -> Error {
     let msg = format!("A header for file {path:?} could not be found.");
     log::warn!("{}", msg);
@@ -91,6 +103,24 @@ mod tests {
         assert_eq!(
             file_with_duplicate_header_created(&old_file, &new_file).to_string(),
             format!("A file {:?} was attempted to be saved with header {:?}, but another file with the same header already existed at {:?}", new_file.serializable_path().unwrap(), new_file.header(), old_file.serializable_path().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_invalid_path_from_url() {
+        let url = lsp_types::Url::parse("file:/testing").unwrap();
+        assert_eq!(
+            invalid_path_from_url(url.clone()).to_string(),
+            format!("Invalid path extracted from url {:?}", url)
+        );
+    }
+
+    #[test]
+    fn test_invalid_overlapping_references_in_file() {
+        let file = File::mock(None);
+        assert_eq!(
+            invalid_overlapping_references_in_file(&file).to_string(),
+            format!("Invalid overlapping references in file: {:?}", file)
         );
     }
 }

--- a/src/lsp/goto.rs
+++ b/src/lsp/goto.rs
@@ -1,34 +1,85 @@
 use lsp_types::{Location, Position, Range, Url};
 
-pub fn find_markdown_reference(url: Url, position: Position) -> Option<Location> {
-    // TODO: use the built index to resolve the title to the correct file
+use crate::ctx::Context;
+use crate::models::{File, Reference};
 
-    let resolved_position = Position {
-        character: 0,
-        line: 0,
+pub fn find_markdown_references(
+    context: &Context,
+    url: Url,
+    position: Position,
+) -> crate::Result<Vec<Location>> {
+    let path = match url.to_file_path() {
+        Ok(path) => path,
+        Err(_) => return Err(crate::errors::invalid_path_from_url(url)),
     };
-    let resolved_url =
-        Url::parse("file:/Users/lancelafontaine/code/grimoire-lsp/src/sample/README.md").unwrap();
-    let _location = Location {
-        uri: resolved_url,
+    let source_file = match File::parse_from_path(path) {
+        Ok(source_file) => source_file,
+        Err(err) => return Err(err),
+    };
+    let references: Vec<&Reference> = source_file
+        .references()
+        .iter()
+        .filter(|reference| reference.location().contains(&position))
+        .collect();
+    if references.len() > 1 {
+        return Err(crate::errors::invalid_overlapping_references_in_file(
+            &source_file,
+        ));
+    }
+    if references.is_empty() {
+        let mut files = Vec::new();
+        context.db().execute(|repository| {
+            files = repository.files().find_all()?;
+            Ok(())
+        })?;
+
+        return files
+            .iter()
+            .map(lsp_location_from_file)
+            .collect::<crate::Result<Vec<Location>>>();
+    }
+    let reference = references[0];
+
+    let mut file_option = None;
+    context.db().execute(|repository| {
+        file_option = repository.files().find(&reference.header())?;
+        Ok(())
+    })?;
+
+    let file = match file_option {
+        Some(file) => file,
+        None => return Ok(Vec::new()),
+    };
+
+    Ok(vec![lsp_location_from_file(&file)?])
+}
+
+fn lsp_location_from_file(file: &File) -> crate::Result<Location> {
+    let position = Position {
+        line: file.header_location().line_position,
+        character: file.header_location().start_char_position as u32,
+    };
+    let path = file.serializable_path()?;
+    let mut prefixed_path = String::from("file:");
+    prefixed_path.push_str(&path);
+    let url = Url::parse(&prefixed_path)?;
+    Ok(Location {
+        uri: url,
         range: Range {
-            start: resolved_position,
-            end: resolved_position,
+            start: position,
+            end: position,
         },
-    };
+    })
+}
 
-    let mut response_position = position;
-    response_position.line = 0;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let response_uri = url;
-    let response_range = Range {
-        start: response_position,
-        end: response_position,
-    };
-    let response_location = Location {
-        uri: response_uri,
-        range: response_range,
-    };
-
-    Some(response_location)
+    #[test]
+    fn test_lsp_location_from_file() {
+        let file = File::mock(None);
+        let location = lsp_location_from_file(&file);
+        assert!(location.is_ok())
+    }
 }

--- a/src/models/file.rs
+++ b/src/models/file.rs
@@ -212,11 +212,20 @@ mod tests {
         let (_tmp_dir, path) = File::mock_disk_file(Some(data));
         let file = File::parse_from_path(path).unwrap();
         let location = Location {
-            line_position: 2,
-            char_position: 16,
+            in_range: false,
+            line_position: 1,
+            start_char_position: 12,
+            end_char_position: 25,
         };
         assert_eq!(file.header_location().line_position, location.line_position);
-        assert_eq!(file.header_location().char_position, location.char_position);
+        assert_eq!(
+            file.header_location().start_char_position,
+            location.start_char_position
+        );
+        assert_eq!(
+            file.header_location().end_char_position,
+            location.end_char_position
+        );
     }
 
     #[test]
@@ -231,8 +240,10 @@ mod tests {
         let (_tmp_dir, path) = File::mock_disk_file(Some(data));
         let file = File::parse_from_path(path.clone()).unwrap();
         let location = Location {
-            line_position: 4,
-            char_position: 16,
+            in_range: true,
+            line_position: 3,
+            start_char_position: 12,
+            end_char_position: 25,
         };
         let reference = Reference::new(path, String::from("Reference1"), location);
         assert_eq!(file.references().len(), 1);
@@ -257,8 +268,10 @@ mod tests {
         let (_tmp_dir, path) = File::mock_disk_file(Some(data));
         let mut file = File::parse_from_path(path.clone()).unwrap();
         let location = Location {
-            line_position: 4,
-            char_position: 16,
+            in_range: true,
+            line_position: 3,
+            start_char_position: 12,
+            end_char_position: 25,
         };
         let reference = Reference::new(path, String::from("Reference1"), location);
         assert_eq!(file.references_mut().len(), 1);

--- a/src/models/location.rs
+++ b/src/models/location.rs
@@ -1,30 +1,57 @@
+use lsp_types::Position;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Location {
-    pub line_position: u64,
-    pub char_position: u64,
+    pub in_range: bool,
+    pub line_position: u32,
+    pub start_char_position: i64,
+    pub end_char_position: i64,
 }
 
-const DEFAULT_LINE_POSITION: u64 = 1;
-const DEFAULT_CHAR_POSITION: u64 = 1;
+const DEFAULT_LINE_POSITION: u32 = 0;
+const DEFAULT_CHAR_POSITION: i64 = -1;
 
 impl Location {
     pub fn next(&mut self, c: char) {
         if c == '\n' {
+            self.in_range = false;
             self.line_position += 1;
-            self.char_position = DEFAULT_CHAR_POSITION;
+            self.start_char_position = DEFAULT_CHAR_POSITION;
+            self.end_char_position = DEFAULT_CHAR_POSITION;
         } else {
-            self.char_position += 1;
+            if !self.in_range {
+                self.start_char_position += 1;
+            }
+            self.end_char_position += 1;
         }
+    }
+
+    pub fn in_range(&mut self) {
+        self.in_range = true;
+    }
+
+    pub fn resume(&mut self) {
+        self.in_range = false;
+        self.start_char_position = self.end_char_position;
+    }
+
+    pub fn contains(&self, position: &Position) -> bool {
+        position.line == self.line_position
+            && self.start_char_position >= 0
+            && position.character >= self.start_char_position as u32
+            && self.end_char_position >= 0
+            && position.character <= self.end_char_position as u32
     }
 }
 
 impl Default for Location {
     fn default() -> Self {
         Self {
-            line_position: DEFAULT_CHAR_POSITION,
-            char_position: DEFAULT_LINE_POSITION,
+            in_range: false,
+            line_position: DEFAULT_LINE_POSITION,
+            start_char_position: DEFAULT_CHAR_POSITION,
+            end_char_position: DEFAULT_CHAR_POSITION,
         }
     }
 }
@@ -37,28 +64,97 @@ mod tests {
     fn location_default() {
         let location = Location::default();
         assert_eq!(location.line_position, DEFAULT_LINE_POSITION);
-        assert_eq!(location.char_position, DEFAULT_CHAR_POSITION);
+        assert_eq!(location.start_char_position, DEFAULT_CHAR_POSITION);
+        assert_eq!(location.end_char_position, DEFAULT_CHAR_POSITION);
     }
 
     #[test]
     fn location_next_newline() {
         let mut location = Location::default();
-        assert_eq!(location.line_position, 1);
-        assert_eq!(location.char_position, 1);
-
         location.next('\n');
-        assert_eq!(location.line_position, 2);
-        assert_eq!(location.char_position, 1);
+        assert_eq!(location.line_position, 1);
+        assert_eq!(location.start_char_position, -1);
+        assert_eq!(location.end_char_position, -1);
     }
 
     #[test]
     fn location_next_not_newline() {
         let mut location = Location::default();
-        assert_eq!(location.line_position, 1);
-        assert_eq!(location.char_position, 1);
-
         location.next('a');
-        assert_eq!(location.line_position, 1);
-        assert_eq!(location.char_position, 2);
+        assert_eq!(location.line_position, 0);
+        assert_eq!(location.start_char_position, 0);
+        assert_eq!(location.end_char_position, 0);
+    }
+
+    #[test]
+    fn location_in_range() {
+        let mut location = Location::default();
+        location.next('a');
+        location.next('b');
+        assert_eq!(location.start_char_position, 1);
+        assert_eq!(location.end_char_position, 1);
+
+        location.in_range();
+        assert_eq!(location.start_char_position, 1);
+        assert_eq!(location.end_char_position, 1);
+
+        location.next('c');
+        assert_eq!(location.start_char_position, 1);
+        assert_eq!(location.end_char_position, 2);
+
+        location.next('\n');
+        assert_eq!(location.start_char_position, -1);
+        assert_eq!(location.end_char_position, -1);
+    }
+
+    #[test]
+    fn location_resume() {
+        let mut location = Location::default();
+        location.next('a');
+        location.next('b');
+        assert_eq!(location.start_char_position, 1);
+        assert_eq!(location.end_char_position, 1);
+
+        location.in_range();
+        location.next('c');
+        assert_eq!(location.start_char_position, 1);
+        assert_eq!(location.end_char_position, 2);
+
+        location.resume();
+        assert_eq!(location.start_char_position, 2);
+        assert_eq!(location.end_char_position, 2);
+
+        location.next('d');
+        assert_eq!(location.start_char_position, 3);
+        assert_eq!(location.end_char_position, 3);
+    }
+
+    #[test]
+    fn location_contains_true() {
+        let mut location = Location::default();
+        location.next('a');
+        location.in_range();
+        location.next('b');
+        location.next('c');
+        assert_eq!(location.start_char_position, 0);
+        assert_eq!(location.end_char_position, 2);
+
+        let assertion1 = location.contains(&Position {
+            line: 0,
+            character: 1,
+        });
+        assert!(assertion1);
+
+        let assertion2 = location.contains(&Position {
+            line: 1,
+            character: 1,
+        });
+        assert!(!assertion2);
+
+        let assertion3 = location.contains(&Position {
+            line: 0,
+            character: 10,
+        });
+        assert!(!assertion3);
     }
 }

--- a/src/models/reference.rs
+++ b/src/models/reference.rs
@@ -105,8 +105,12 @@ mod tests {
             Location::default().line_position
         );
         assert_eq!(
-            reference.location().char_position,
-            Location::default().char_position
+            reference.location().start_char_position,
+            Location::default().start_char_position
+        );
+        assert_eq!(
+            reference.location().end_char_position,
+            Location::default().end_char_position
         );
     }
 

--- a/src/repositories/files_repository.rs
+++ b/src/repositories/files_repository.rs
@@ -10,18 +10,39 @@ impl<'a> FilesRepository<'a> {
     }
 
     pub fn create_file(&self, file: &File) -> crate::Result<()> {
-        let key = serde_json::to_vec(&file.header())?;
+        let header = &file.header();
+        let key = serde_json::to_vec(header)?;
         let value = serde_json::to_vec(file)?;
 
-        if let Some(old_value) = self.table.get(&key)? {
-            let old_value: &[u8] = &old_value;
-            let old_file: File = serde_json::from_slice(old_value)?;
+        if let Some(old_file) = self.find(header)? {
             return Err(crate::errors::file_with_duplicate_header_created(
                 &old_file, file,
             ));
         }
         self.table.insert(&key, value)?;
         Ok(())
+    }
+
+    pub fn find(&self, header: &str) -> crate::Result<Option<File>> {
+        let key = serde_json::to_vec(&header)?;
+        if let Some(value) = self.table.get(&key)? {
+            let value: &[u8] = &value;
+            let file: File = serde_json::from_slice(value)?;
+            return Ok(Some(file));
+        }
+        Ok(None)
+    }
+
+    pub fn find_all(&self) -> crate::Result<Vec<File>> {
+        let mut files = Vec::new();
+        for entry_result in self.table.iter() {
+            let entry = entry_result?;
+            let (_, value) = entry;
+            let value: &[u8] = &value;
+            let file: File = serde_json::from_slice(value)?;
+            files.push(file);
+        }
+        Ok(files)
     }
 }
 
@@ -44,6 +65,26 @@ mod tests {
         let repository = repository_builder.files();
         let file = File::mock(None);
         assert!(repository.create_file(&file).is_ok());
-        assert!(!repository.create_file(&file).is_ok());
+        assert!(repository.create_file(&file).is_err());
+    }
+
+    #[test]
+    fn test_files_repositority_find() {
+        let repository_builder = RepositoryBuilder::mock();
+        let repository = repository_builder.files();
+        let file = File::mock(None);
+        assert!(repository.find(&file.header()).unwrap().is_none());
+        assert!(repository.create_file(&file).is_ok());
+        assert!(repository.find(&file.header()).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_files_repositority_find_all() {
+        let repository_builder = RepositoryBuilder::mock();
+        let repository = repository_builder.files();
+        assert!(repository.find_all().unwrap().is_empty());
+        let file1 = File::mock(None);
+        assert!(repository.create_file(&file1).is_ok());
+        assert_eq!(repository.find_all().unwrap().len(), 1);
     }
 }


### PR DESCRIPTION
- Changes how header locations are tracked and indexed: they are now a range bound by the beginning and end delimiters of a file or reference header
- Implements a repository method to find a specific file by its header
- Implements a repository method to return all fixed currently indexed
- Using the files index, navigates to the file identified by the header contained within a reference on a goto LSP request
- Using the files index, displays and searches over all file headers when performing a goto LSP request outside a reference
